### PR TITLE
Minor text updates / changes

### DIFF
--- a/src/3.html
+++ b/src/3.html
@@ -111,7 +111,7 @@
   <div class="caption"><em>Figure 3.6.</em> List of packets in VRTA</div>
 </p>
 
-<p>One last nail in the broadband myth's coffin - most browsers only establish two connections per domain name. This means that only two files can be downloaded at the same time, which results in underutilizing the fat pipe. This behavior is in the HTTP standard, so we cannot blame browsers for following the standard. The problem is that the standard was created a long time ago. Luckily, there's light at the end of the tunnel - new browsers (Firefox 3, Safari 4, IE8) offer 6 to 8 connections. But legacy browsers with large market share such as IE6 and IE7 only use 2 parallel connections.
+<p>One last nail in the broadband myth's coffin - most browsers only establish two connections per domain name. This means that only two files can be downloaded at the same time, which results in underutilizing the fat pipe. This behavior is in the HTTP standard, so we cannot blame browsers for following the standard. The problem is that the standard was created a long time ago. Luckily, there's light at the end of the tunnel - new browsers (Firefox 3+, Safari 4+, Chrome, Opera 10+, IE8+) offer 6 to 8 connections. But legacy browsers with large market share such as IE6 and IE7 only use 2 parallel connections.
 
 <h3>Take Home</h3>
 


### PR DESCRIPTION
Hi

A quick summary of my changes:
1. Added the HTML entity for the é in café as I could only see garbled text i.e. cafÃ©
2. Added a '+' after the browser version numbers when discussing parallel connections to try and future proof the text going forwards e.g. so instead of Firefox 3 it now reads Firefox 3+ and therefore includes Firefox 4, etc., etc.

Hope this helps.

Ian
