### PR TITLE
JPEGTran example command doesn't work.

### DIFF
--- a/src/5.html
+++ b/src/5.html
@@ -236,7 +236,7 @@
 
 <p>Running all JPEGs through JPEGTran resulted in <strong>13.08%</strong> savings, using the command:
 
-<pre>$ jpegtran -copy none -optimize source.jpg destination.jpg</pre>
+<pre>$ jpegtran -copy none -outfile destination.jpg -optimize source.jpg</pre>
 
 <p>Again, you can do better by trying progressive encoding and picking the smaller result.
 


### PR DESCRIPTION
Should be 

`jpegtran -copy none -outfile destination.jpg -optimize source.jpg`

My JPEGTran version is 7  27-Jun-2009.
